### PR TITLE
ELK 스택 연동 작업

### DIFF
--- a/composefiles/dev/docker-compose.yml
+++ b/composefiles/dev/docker-compose.yml
@@ -97,7 +97,8 @@ services:
           - redis-dev.polymarket.kr
   elasticsearch:
     container_name: polymarket-elasticsearch
-    image: elasticsearch:7.9.0
+    build:
+      context: ./elasticsearch
     ports:
      - 9200:9200
      - 9300:9300
@@ -105,7 +106,7 @@ services:
      - /home/polymarket/elasticsearch/data:/usr/share/elasticsearch/data
     environment:
      - discovery.type=single-node
-     - "ES_JAVA_OPTS=-Xms512m -Xmx1024m"
+     - "ES_JAVA_OPTS=-Xms1024m -Xmx2048m"
      - TZ=Asia/Seoul
      - bootstrap.memory_lock=true
     ulimits:
@@ -125,18 +126,24 @@ services:
       - xpack.monitoring.enabled=true
       - xpack.monitoring.elasticsearch.hosts=http://es-dev.polymarket.kr
     volumes:
-      - ./logstash/logstash.conf:/usr/shares/logstash/config/logstash.conf
-      - ./logstash/mysql-connector-java-8.0.29.jar:/usr/shares/logstash/mysql-connector-java-8.0.29.jar
+      - ./logstash/logstash.conf:/usr/share/logstash/config/logstash.conf
+      - ./logstash/mysql-connector-java-8.0.29.jar:/usr/share/logstash/logstash-core/lib/jar/mysql-connector-java-8.0.29.jar:ro
+    command: logstash -f /usr/share/logstash/config/logstash.conf
     depends_on:
       - elasticsearch
       - mysql
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1024M
     networks:
       polymarket-network:
         aliases: 
           - logstash-dev.polymarket.kr
   kibana:
     container_name: polymarket-kibana
-    image: kibana:7.9.0
+    image: kibana:7.17.3
     ports:
      - 5601:5601
     environment:

--- a/composefiles/dev/elasticsearch/Dockerfile
+++ b/composefiles/dev/elasticsearch/Dockerfile
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.14.1
+RUN bin/elasticsearch-plugin install analysis-nori

--- a/composefiles/dev/logstash/logstash.conf
+++ b/composefiles/dev/logstash/logstash.conf
@@ -1,0 +1,26 @@
+input {
+  jdbc {
+    jdbc_driver_library => "/usr/share/logstash/logstash-core/lib/jar/mysql-connector-java-8.0.29.jar"
+    jdbc_driver_class => "com.mysql.jdbc.Driver"
+    jdbc_connection_string => "jdbc:mysql://mysql-dev.polymarket.kr:3306/polymarket"
+    jdbc_user => "polymarket-logstash"
+    jdbc_password => "logstash1!"
+    jdbc_paging_enabled => true
+    tracking_column => "update_date"
+    use_column_value => true
+    tracking_column_type => "timestamp"
+    schedule => "*/5 * * * * *"
+    statement => "SELECT * FROM polymarket.product WHERE update_date > :sql_last_value AND update_date < NOW() ORDER BY update_date ASC"
+  }
+}
+filter {
+  mutate {
+    remove_field => ["@version", "@timestamp"]
+  }
+}
+output {
+  elasticsearch {
+      hosts => ["es-dev.polymarket.kr:9200"]
+      index => "product_search_idx"
+  }
+}


### PR DESCRIPTION
직업내역
- elasticsearch 버전업 (pit, point in time 기능 활성화 목적)
- elasticsearch nori 형태소 분석기 플러그인 추가
- logstash 파이프라인 추가(mysql -> elasticsearch 로 데이터 동기화)

logstash에 있는 db계정은 개발서버 내부에서 사용하는 172.x.x.x 사설 ip 내에서만 유효한 계정이라 노출되도 큰 타격이 없을듯
cf) https://www.notion.so/PolyMarket-DDL-4a497c6c32884f67aa72b12bc1057b36

